### PR TITLE
Simplified script for showing informational notification types, like acknowledge, downtimestart & downtimeend

### DIFF
--- a/slack-host-notification.sh
+++ b/slack-host-notification.sh
@@ -5,72 +5,50 @@ SLACK_WEBHOOK_URL="<YOUR_SLACK_WEBHOOK_INTEGRATION_URL>"
 SLACK_CHANNEL="#alerts"
 SLACK_BOTNAME="icinga2"
 
-
-if [ "$NOTIFICATIONTYPE" = "ACKNOWLEDGEMENT" ] || [ "$NOTIFICATIONTYPE" = "DOWNTIMESTART" ] || [ "$NOTIFICATIONTYPE" = "DOWNTIMEEND" ]
-then
-  COLOR="#33FFE3"
-#Send message to Slack
-read -d '' PAYLOAD << EOF
-{
-  "channel": "${SLACK_CHANNEL}",
-  "username": "${SLACK_BOTNAME}",
-  "attachments": [
-    {
-      "fallback": "${NOTIFICATIONTYPE} ${HOSTSTATE}: ${HOSTDISPLAYNAME}",
-      "color": "${COLOR}",
-      "fields": [
-        {
-          "title": "${NOTIFICATIONTYPE}",
-          "value": "${NOTIFICATIONCOMMENT} - ${NOTIFICATIONAUTHORNAME}"
-        },
-        {
-          "title": "Info",
-          "value": "${HOSTOUTPUT}",
-          "short": false
-        },
-        {
-          "title": "Host",
-          "value": "<${ICINGA_HOSTNAME}/monitoring/host/services?host=${HOSTNAME}|${HOSTDISPLAYNAME}>",
-          "short": true
-        },
-        {
-          "title": "State",
-          "value": "${HOSTSTATE}",
-          "short": true
-        }
-      ]
-    }
-  ]
-}
-EOF
-else
-
-
-#Set the message icon based on ICINGA Host state
+# Set the color based on host state
 if [ "$HOSTSTATE" = "DOWN" ]
 then
-    COLOR="danger"
+    COLOR="#FF5566"
 elif [ "$HOSTSTATE" = "UP" ]
 then
-    COLOR="good"
+    COLOR="#44BB77"
 else
     COLOR=""
 fi
 
-#Send message to Slack
+# Overwrite color for informational notification types
+if [ "$NOTIFICATIONTYPE" = "ACKNOWLEDGEMENT" ] || [ "$NOTIFICATIONTYPE" = "DOWNTIMESTART" ] || [ "$NOTIFICATIONTYPE" = "DOWNTIMEEND" ]
+then
+  COLOR="#7F7F7F"
+fi
+
+# Determine information to display
+if [ -z "$NOTIFICATIONCOMMENT" ]
+then
+  INFORMATION="${HOSTOUTPUT}"
+else
+  INFORMATION="${NOTIFICATIONCOMMENT}"
+fi
+
+# Send message to Slack
 read -d '' PAYLOAD << EOF
 {
   "channel": "${SLACK_CHANNEL}",
   "username": "${SLACK_BOTNAME}",
   "attachments": [
     {
-      "fallback": "${HOSTSTATE}: ${HOSTDISPLAYNAME}",
+      "fallback": "${NOTIFICATIONTYPE} - ${HOSTSTATE}: ${HOSTDISPLAYNAME}",
       "color": "${COLOR}",
       "fields": [
         {
-          "title": "Info",
-          "value": "${HOSTOUTPUT}",
-          "short": false
+          "title": "Type",
+          "value": "${NOTIFICATIONTYPE}",
+          "short": true
+        },
+        {
+          "title": "State",
+          "value": "${HOSTSTATE}",
+          "short": true
         },
         {
           "title": "Host",
@@ -78,16 +56,14 @@ read -d '' PAYLOAD << EOF
           "short": true
         },
         {
-          "title": "State",
-          "value": "${HOSTSTATE}",
-          "short": true
+          "title": "Information",
+          "value": "${HOSTOUTPUT}\n${NOTIFICATIONCOMMENT}",
+          "short": false
         }
       ]
     }
   ]
 }
 EOF
-
-fi
 
 curl --connect-timeout 30 --max-time 60 -s -S -X POST -H 'Content-type: application/json' --data "${PAYLOAD}" "${SLACK_WEBHOOK_URL}"

--- a/slack-service-notification.sh
+++ b/slack-service-notification.sh
@@ -5,60 +5,16 @@ SLACK_WEBHOOK_URL="<YOUR_SLACK_WEBHOOK_INTEGRATION_URL>"
 SLACK_CHANNEL="#alerts"
 SLACK_BOTNAME="icinga2"
 
-
-if [ "$NOTIFICATIONTYPE" = "ACKNOWLEDGEMENT" ] || [ "$NOTIFICATIONTYPE" = "DOWNTIMESTART" ] || [ "$NOTIFICATIONTYPE" = "DOWNTIMEEND" ]
-then
-  COLOR="#FFB6C1"
-  read -d '' PAYLOAD << EOF
-{
-  "channel": "${SLACK_CHANNEL}",
-  "username": "${SLACK_BOTNAME}",
-  "attachments": [
-    {
-      "fallback": "${NOTIFICATIONTYPE}: ${SERVICESTATE}: ${HOSTDISPLAYNAME} - ${SERVICEDISPLAYNAME}",
-      "color": "${COLOR}",
-      "fields": [
-        {
-          "title": "${NOTIFICATIONTYPE}",
-          "value": "${NOTIFICATIONCOMMENT} - ${NOTIFICATIONAUTHORNAME}"
-        },
-        {
-          "title": "Service output",
-          "value": "${SERVICEOUTPUT}",
-          "short": false
-        },
-        {
-          "title": "Host",
-          "value": "<${ICINGA_HOSTNAME}/monitoring/host/services?host=${HOSTNAME}|${HOSTDISPLAYNAME}>",
-          "short": true
-        },
-        {
-          "title": "Service",
-          "value": "<${ICINGA_HOSTNAME}/monitoring/service/show?host=${HOSTNAME}&service=${SERVICEDESC}|${SERVICEDISPLAYNAME}>",
-          "short": true
-        },
-        {
-          "title": "State",
-          "value": "${SERVICESTATE}",
-          "short": true
-        }
-      ]
-    }
-  ]
-}
-EOF
-else
-
-#Set the message icon based on ICINGA service state
+# Set the message icon based on ICINGA service state
 if [ "$SERVICESTATE" = "CRITICAL" ]
 then
-    COLOR="danger"
+    COLOR="#FF5566"
 elif [ "$SERVICESTATE" = "WARNING" ]
 then
-    COLOR="warning"
+    COLOR="#FFAA44"
 elif [ "$SERVICESTATE" = "OK" ]
 then
-    COLOR="good"
+    COLOR="#44BB77"
 elif [ "$SERVICESTATE" = "UNKNOWN" ]
 then
     COLOR="#800080"
@@ -66,20 +22,39 @@ else
     COLOR=""
 fi
 
-#Send message to Slack
+# Overwrite color for informational notification types
+if [ "$NOTIFICATIONTYPE" = "ACKNOWLEDGEMENT" ] || [ "$NOTIFICATIONTYPE" = "DOWNTIMESTART" ] || [ "$NOTIFICATIONTYPE" = "DOWNTIMEEND" ]
+then
+  COLOR="#7F7F7F"
+fi
+
+# Determine information to display
+if [ -z "$NOTIFICATIONCOMMENT" ]
+then
+  INFORMATION="${SERVICEOUTPUT}"
+else
+  INFORMATION="${NOTIFICATIONCOMMENT}"
+fi
+
+# Send message to Slack
 read -d '' PAYLOAD << EOF
 {
   "channel": "${SLACK_CHANNEL}",
   "username": "${SLACK_BOTNAME}",
   "attachments": [
     {
-      "fallback": "${SERVICESTATE}: ${HOSTDISPLAYNAME} - ${SERVICEDISPLAYNAME}",
+      "fallback": "${NOTIFICATIONTYPE} - ${SERVICESTATE}: ${HOSTDISPLAYNAME} - ${SERVICEDISPLAYNAME}",
       "color": "${COLOR}",
       "fields": [
         {
-          "title": "Service output",
-          "value": "${SERVICEOUTPUT}",
-          "short": false
+          "title": "Type",
+          "value": "${NOTIFICATIONTYPE}",
+          "short": true
+        },
+        {
+          "title": "State",
+          "value": "${SERVICESTATE}",
+          "short": true
         },
         {
           "title": "Host",
@@ -92,16 +67,14 @@ read -d '' PAYLOAD << EOF
           "short": true
         },
         {
-          "title": "State",
-          "value": "${SERVICESTATE}",
-          "short": true
-        }
+          "title": "Information",
+          "value": "${INFORMATION}",
+          "short": false
+        },
       ]
     }
   ]
 }
 EOF
-
-fi
 
 curl --connect-timeout 30 --max-time 60 -s -S -X POST -H 'Content-type: application/json' --data "${PAYLOAD}" "${SLACK_WEBHOOK_URL}"


### PR DESCRIPTION
Improvement: Changed slack colors to be the same as Icinga is using in their interface.
Improvement: Added notification type to be displayed. For informational notification types the color grey will be used, like in the Icinga interface.
Improvement: Simplified script so that comment is shown when entered. If no comment is present either the service output or host output is being displayed.